### PR TITLE
Fix issue on saving products with no categories

### DIFF
--- a/Observer/SynchronizeProduct.php
+++ b/Observer/SynchronizeProduct.php
@@ -106,6 +106,8 @@ class SynchronizeProduct implements ObserverInterface
 				// Categories
 				$category_data = array();
 				$objectMan =  \Magento\Framework\App\ObjectManager::getInstance();
+				//Initialize array, in case a product doesn't have any categories we will still have the array.
+				$categories = [];
 				foreach ($product->getCategoryIds() as $category_id)
 				{
 					$categories[] = $category_id;

--- a/Observer/SynchronizeProduct.php
+++ b/Observer/SynchronizeProduct.php
@@ -106,7 +106,6 @@ class SynchronizeProduct implements ObserverInterface
 				// Categories
 				$category_data = array();
 				$objectMan =  \Magento\Framework\App\ObjectManager::getInstance();
-				//Initialize array, in case a product doesn't have any categories we will still have the array.
 				$categories = [];
 				foreach ($product->getCategoryIds() as $category_id)
 				{


### PR DESCRIPTION
When a product doesn't have any categories saving the product fails due to the categories array not being initialized.

This pull request fixes that by introducing a default, empty array.
