### PR TITLE
Catch global Throwable

### DIFF
--- a/Observer/SynchronizeProduct.php
+++ b/Observer/SynchronizeProduct.php
@@ -206,7 +206,7 @@ class SynchronizeProduct implements ObserverInterface
 			{
 				$this->mcapi->DebugCall($e->getMessage());
 			}
-			catch (Exception $e)
+			catch (\Throwable $e)
 			{
 				$this->mcapi->DebugCall($e->getMessage());
 			}


### PR DESCRIPTION
Use the global namespace Throwable to catch all errors.

This also applies for all the other observers, but haven't changed them.

Error was:
```
Fatal Error: 'Uncaught Error: Call to a member function getQty() on null in \/var\/domains\/mydomain.com\/releases\/1.1\/vendor\/mailcampaigns\/magento2connector\/Observer\/SynchronizeProduct.php:166
```
Which I though was weird because you have a try/catch here.